### PR TITLE
Travis CI: Test on current versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
   - "pypy3"
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
-  - "pypy3.5"
+  - "3.7"
+  - "3.8"
+  - "pypy3"
 
 install:
   - pip install -r requirements-dev.txt
@@ -17,7 +17,7 @@ script:
   - make clear_coverage
   - make run_unit_tests
   - make run_integration_tests
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3.5' ]]; then make run_acceptance_tests; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3' ]]; then make run_acceptance_tests; fi
 
 after_success:
   - make coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
   - "pypy3"
-
+jobs:
+  allow_failures:
+    - python: "2.7"
 install:
   - pip install -r requirements-dev.txt
   - pip install codecov


### PR DESCRIPTION
Python 3.9 is now available on Travis CI.

Output: https://travis-ci.org/github/magmax/colorize/pull_requests